### PR TITLE
Map page

### DIFF
--- a/app/src/main/java/com/familystalking/app/MainActivity.kt
+++ b/app/src/main/java/com/familystalking/app/MainActivity.kt
@@ -19,6 +19,7 @@ import com.familystalking.app.presentation.MainViewModel
 import com.familystalking.app.presentation.forgotpassword.ForgotPasswordScreen
 import com.familystalking.app.presentation.home.HomeScreen
 import com.familystalking.app.presentation.login.LoginScreen
+import com.familystalking.app.presentation.map.MapScreen
 import com.familystalking.app.presentation.navigation.Screen
 import com.familystalking.app.presentation.signup.SignupScreen
 import com.familystalking.app.ui.theme.FamilyStalkingTheme
@@ -45,7 +46,7 @@ class MainActivity : ComponentActivity() {
                     LaunchedEffect(sessionState) {
                         when (sessionState) {
                             SessionState.Authenticated -> {
-                                navController.navigate(Screen.Home.route) {
+                                navController.navigate(Screen.Map.route) {
                                     popUpTo(Screen.Login.route) { inclusive = true }
                                 }
                             }
@@ -76,9 +77,25 @@ class MainActivity : ComponentActivity() {
                         composable(Screen.Home.route) {
                             HomeScreen(navController)
                         }
+                        composable(Screen.Map.route) {
+                            MapScreen(navController)
+                        }
+                        // Add other routes for the bottom navigation
+                        composable(Screen.Agenda.route) {
+                            // Placeholder for Agenda screen
+                            HomeScreen(navController) // Temporarily using HomeScreen
+                        }
+                        composable(Screen.Family.route) {
+                            // Placeholder for Family screen
+                            HomeScreen(navController) // Temporarily using HomeScreen
+                        }
+                        composable(Screen.Settings.route) {
+                            // Placeholder for Settings screen
+                            HomeScreen(navController) // Temporarily using HomeScreen
+                        }
                     }
                 }
             }
         }
     }
-} 
+}

--- a/app/src/main/java/com/familystalking/app/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/familystalking/app/presentation/login/LoginViewModel.kt
@@ -45,15 +45,15 @@ class LoginViewModel @Inject constructor(
 
     fun onSignIn() {
         if (!validateInput()) return
-        
+
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null
-            
+
             when (val result = authenticationRepository.signIn(_email.value, _password.value)) {
                 is AuthResult.Success -> {
                     _isLoading.value = false
-                    _navigateTo.value = Screen.Home.route
+                    _navigateTo.value = Screen.Map.route
                 }
                 is AuthResult.Error -> {
                     _error.value = result.error
@@ -107,4 +107,4 @@ class LoginViewModel @Inject constructor(
     fun onNavigated() {
         _navigateTo.value = null
     }
-} 
+}

--- a/app/src/main/java/com/familystalking/app/presentation/map/MapScreen.kt
+++ b/app/src/main/java/com/familystalking/app/presentation/map/MapScreen.kt
@@ -1,2 +1,64 @@
 package com.familystalking.app.presentation.map
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.familystalking.app.presentation.navigation.BottomNavBar
+
+@Composable
+fun MapScreen(navController: NavController) {
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // Map placeholder - this will be replaced with actual Google Maps implementation
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .background(Color(0xFFE8F0E9))
+        ) {
+            // Placeholder for the map
+            Column(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "Google Maps",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Map will be displayed here once API key is configured",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Bottom Navigation Bar
+        BottomNavBar(
+            currentRoute = "map",
+            navController = navController
+        )
+    }
+}

--- a/app/src/main/java/com/familystalking/app/presentation/map/MapScreen.kt
+++ b/app/src/main/java/com/familystalking/app/presentation/map/MapScreen.kt
@@ -1,0 +1,2 @@
+package com.familystalking.app.presentation.map
+

--- a/app/src/main/java/com/familystalking/app/presentation/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/familystalking/app/presentation/navigation/BottomNavBar.kt
@@ -1,5 +1,6 @@
 package com.familystalking.app.presentation.navigation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Icon
@@ -10,6 +11,7 @@ import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.familystalking.app.presentation.navigation.NavItem
@@ -19,11 +21,16 @@ fun BottomNavBar(
     currentRoute: String,
     navController: NavController
 ) {
+    // Pure white color for the navigation bar
+    val pureWhite = Color(0xFFFFFFFF)
+
     NavigationBar(
         modifier = Modifier
             .fillMaxWidth()
             .height(64.dp),
-        containerColor = MaterialTheme.colorScheme.surface
+        containerColor = pureWhite,
+        contentColor = MaterialTheme.colorScheme.primary,
+        tonalElevation = 0.dp // Remove any elevation shadow that might affect color
     ) {
         NavItem.items.forEach { navItem ->
             NavigationBarItem(
@@ -54,7 +61,7 @@ fun BottomNavBar(
                 colors = NavigationBarItemDefaults.colors(
                     selectedIconColor = MaterialTheme.colorScheme.primary,
                     selectedTextColor = MaterialTheme.colorScheme.primary,
-                    indicatorColor = MaterialTheme.colorScheme.surface,
+                    indicatorColor = pureWhite,
                     unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/familystalking/app/presentation/signup/SignupViewModel.kt
+++ b/app/src/main/java/com/familystalking/app/presentation/signup/SignupViewModel.kt
@@ -53,15 +53,15 @@ class SignupViewModel @Inject constructor(
 
     fun onSignUp() {
         if (!validateInput()) return
-        
+
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null
-            
+
             when (val result = authenticationRepository.signUp(_email.value, _password.value)) {
                 is AuthResult.Success -> {
                     _isLoading.value = false
-                    _navigateTo.value = Screen.Home.route
+                    _navigateTo.value = Screen.Map.route
                 }
                 is AuthResult.Error -> {
                     _error.value = result.error
@@ -96,4 +96,4 @@ class SignupViewModel @Inject constructor(
     fun onNavigated() {
         _navigateTo.value = null
     }
-} 
+}

--- a/app/src/main/java/com/familystalking/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/familystalking/app/ui/theme/Theme.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -14,10 +15,10 @@ import androidx.core.view.WindowCompat
 private val LightColorScheme = lightColorScheme(
     primary = PrimaryGreen,
     onPrimary = OnPrimaryGreen,
-    background = BackgroundColor,
+    background = Color.White,
     onBackground = OnBackgroundColor,
     error = ErrorColor,
-    surface = BackgroundColor,
+    surface = Color.White,
     onSurface = OnBackgroundColor,
     surfaceVariant = TextFieldBackgroundColor,
     onSurfaceVariant = OnBackgroundColor.copy(alpha = 0.6f)
@@ -31,7 +32,7 @@ fun FamilyStalkingTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = BackgroundColor.toArgb()
+            window.statusBarColor = Color.White.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
         }
     }
@@ -40,4 +41,4 @@ fun FamilyStalkingTheme(
         colorScheme = LightColorScheme,
         content = content
     )
-} 
+}


### PR DESCRIPTION
This pull request introduces a new `MapScreen` to the app, updates navigation to make the map the default landing page after login or signup, and includes UI improvements such as a redesigned bottom navigation bar and a lighter theme. Below are the most important changes grouped by theme:

### New Feature: Map Screen
* Added a new `MapScreen` composable as a placeholder for future Google Maps integration. It includes a basic layout and a bottom navigation bar. (`app/src/main/java/com/familystalking/app/presentation/map/MapScreen.kt`)

### Navigation Updates
* Updated the navigation logic to make the `MapScreen` the default landing page after successful login or signup. (`app/src/main/java/com/familystalking/app/MainActivity.kt`, `app/src/main/java/com/familystalking/app/presentation/login/LoginViewModel.kt`, `app/src/main/java/com/familystalking/app/presentation/signup/SignupViewModel.kt`) [[1]](diffhunk://#diff-43982bcf1c598a13831ff89bc30e399722734df551b6baf081ca36dee862cd24L48-R49) [[2]](diffhunk://#diff-9fd27868ca555f2874496696f3adbc7d85905beed1bf55b8216f7d97e3745834L56-R56) [[3]](diffhunk://#diff-71192ccdd0c1769be66bec9ce24f06c38451aacdcb4d4c0a383fe4c84c1d5dceL64-R64)
* Added routes for the `MapScreen` and placeholders for `Agenda`, `Family`, and `Settings` screens in the navigation graph. (`app/src/main/java/com/familystalking/app/MainActivity.kt`)

### UI Enhancements
* Redesigned the bottom navigation bar with a pure white background, primary color for selected items, and no elevation shadow. (`app/src/main/java/com/familystalking/app/presentation/navigation/BottomNavBar.kt`) [[1]](diffhunk://#diff-bbdad4d14dfe3675d98674ac3ab798f025c8d2fb03388cec4dab8ddd27ecbc52R24-R33) [[2]](diffhunk://#diff-bbdad4d14dfe3675d98674ac3ab798f025c8d2fb03388cec4dab8ddd27ecbc52L57-R64)
* Updated the app's theme to use a white background and surface color, and adjusted the status bar color accordingly. (`app/src/main/java/com/familystalking/app/ui/theme/Theme.kt`) [[1]](diffhunk://#diff-cc2f94925868953d1fd28957fffd7f0e7d42ec9e047a15736ecf1970f4c7f60aR10-R21) [[2]](diffhunk://#diff-cc2f94925868953d1fd28957fffd7f0e7d42ec9e047a15736ecf1970f4c7f60aL34-R35)